### PR TITLE
BUGFIX MetaImage is secondary to FeaturedImage on BlogPost

### DIFF
--- a/src/Extensions/BlogPostExtension.php
+++ b/src/Extensions/BlogPostExtension.php
@@ -21,6 +21,10 @@ class BlogPostExtension extends \SilverStripe\CMS\Model\SiteTreeExtension
 
     public function getSocialMetaImage()
     {
+        if (($image = $this->owner->MetaImage()) && $image->exists()) {
+            return $image;
+        }
+        
         if ($this->owner->FeaturedImageID && $this->owner->FeaturedImage()) {
             return $this->owner->FeaturedImage();
         }


### PR DESCRIPTION
resolves #8 

This solution is semi-redundant as I'm just adding a check for the `MetaImage` which is from the later called `getDefaultSocialMetaImage` method if neither the `MetaImage` or `FeaturedImage` is available. I figured the order of operations for a blog post would be:

1. MetaImage
2. FeaturedImage
3. The remaining fallbacks from the getDefaultSocialMetaImage method

Happy to adjust if needed.