### PR TITLE
Fix order of arguments in insertBefore call

### DIFF
--- a/src/Extensions/SiteTreeExtension.php
+++ b/src/Extensions/SiteTreeExtension.php
@@ -924,8 +924,8 @@ class SiteTreeExtension extends \SilverStripe\CMS\Model\SiteTreeExtension
                 );
 
         } else {
-            $fields->insertBefore($metaTitleField, 'MetaDescription');
-            $fields->insertBefore($metaURLField, 'MetaDescription');
+            $fields->insertBefore('MetaDescription', $metaTitleField);
+            $fields->insertBefore('MetaDescription', $metaURLField);
         }
     }
 }


### PR DESCRIPTION
Minor fix for `insertBefore()` arguments still in the old order.